### PR TITLE
Set the physics parameters of the mob before adding it to the scene tree

### DIFF
--- a/dodge_the_creeps_3d/Main.gd
+++ b/dodge_the_creeps_3d/Main.gd
@@ -15,19 +15,21 @@ func _unhandled_input(event):
 
 
 func _on_MobTimer_timeout():
-	# Create a Mob instance and add it to the scene.
+	# Create a new instance of the Mob scene.
 	var mob = mob_scene.instance()
 
-	# Choose a random location on Path2D.
+	# Choose a random location on the SpawnPath.
 	var mob_spawn_location = get_node("SpawnPath/SpawnLocation")
 	mob_spawn_location.unit_offset = randf()
 
+	# Communicate the spawn location and the player's location to the mob.
 	var player_position = $Player.transform.origin
+	mob.initialize(mob_spawn_location.translation, player_position)
 
+	# Spawn the mob by adding it to the Main scene.
 	add_child(mob)
 	# We connect the mob to the score label to update the score upon squashing a mob.
 	mob.connect("squashed", $UserInterface/ScoreLabel, "_on_Mob_squashed")
-	mob.initialize(mob_spawn_location.translation, player_position)
 
 
 func _on_Player_hit():

--- a/dodge_the_creeps_3d/Mob.gd
+++ b/dodge_the_creeps_3d/Mob.gd
@@ -17,8 +17,7 @@ func _physics_process(_delta):
 
 
 func initialize(start_position, player_position):
-	translation = start_position
-	look_at(player_position, Vector3.UP)
+	look_at_from_position(start_position, player_position, Vector3.UP)
 	rotate_y(rand_range(-PI / 4, PI / 4))
 
 	var random_speed = rand_range(min_speed, max_speed)


### PR DESCRIPTION
This follows the recommendation from https://github.com/godotengine/godot/issues/45638.

Fixes the bug in the demo which is confusing users (reported e.g. at https://github.com/godotengine/godot/issues/58132 and https://github.com/godotengine/godot/issues/58445).